### PR TITLE
chore:(purposes): change iof payment processing inbound to 0.38 #id 101347

### DIFF
--- a/src/tax-calculator/settings.ts
+++ b/src/tax-calculator/settings.ts
@@ -15,7 +15,7 @@ const settings = Object.freeze({
     PAYMENT_PROCESSING: {
       INBOUND: {
         IOF: {
-          value: 0
+          value: 0.38
         }
       },
       OUTBOUND: {


### PR DESCRIPTION
This PR is related to task [101347](https://remessaonline.kanbanize.com/ctrl_board/31/cards/101347/details/)

- change the IOF tax for inbound operations of purpose PAYMENT_PROCESSING (Bacen 34052) to 0,38.